### PR TITLE
New FW and reboot survival

### DIFF
--- a/fix-mtu.service
+++ b/fix-mtu.service
@@ -4,7 +4,7 @@ After=network.target
 Wants=network.target
 
 [Service]
-ExecStart=/bin/bash /data/fix-mtu/monitor-mtu.sh
+ExecStart=/bin/bash cd /data/fix-mtu;chmod +x *mtu*;/bin/bash /data/fix-mtu/monitor-mtu.sh
 Restart=always
 RestartSec=2
 StandardOutput=journal

--- a/monitor-mtu.sh
+++ b/monitor-mtu.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
-
-ip monitor link | while read -r line; do
-  if [[ "$line" == *"ppp0"* && "$line" == *"mtu"* ]]; then
-    echo "MTU change detected on ppp0: $line"
-    /data/fix-mtu/fix-mtu.sh 
-  fi
+attempt=1
+while [ ! -f /sys/class/net/ppp0/mtu ];
+do
+	echo "ppp0 device not ready - attempt #$attempt"
+	(( attempt++ ))
+	sleep 15
 done
+MTU=$(cat /sys/class/net/ppp0/mtu)
+echo "MTU for ppp0 on startup is $MTU"
+if [ "$MTU" -eq 1492 ]; then
+	/data/fix-mtu/fix-mtu.sh 
+else
+	ip monitor link | while read -r line; do
+	  if [[ "$line" == *"ppp0"* && "$line" == *"mtu"* ]]; then
+		echo "MTU change detected on ppp0: $line"
+		/data/fix-mtu/fix-mtu.sh 
+	  fi
+	done
+fi


### PR DESCRIPTION
**1. Survives the firmware upgrade between 4.x and 5.x**

- fix-mtu.service takes care of making the required scripts executable. 

**2. Survives a reboot**

- monitor-mtu awaits for the mtu to be readable upon boot, initially checking it's valid, and performing the changes. 