### PR TITLE
feat: Display warning on Cloud Gateway Fiber

### DIFF
--- a/fix-mtu.sh
+++ b/fix-mtu.sh
@@ -29,7 +29,7 @@ if [ "$INTERFACE_MTU" -ne $MTU ]; then
   # ifconfig ${WAN_INTERFACE} up
   killall pppd
   sleep 1
-  killall -HUP dnscrypt-proxy dnsmasq
+  killall -q -HUP dnsmasq dnscrypt-proxy || :
 else
   echo "MTU is OK"
 fi

--- a/fix-mtu.sh
+++ b/fix-mtu.sh
@@ -17,19 +17,32 @@ fi
 
 INTERFACE_MTU=$(cat "$MTUPATH")
 
-if [ "$INTERFACE_MTU" -ne $MTU ]; then
-  echo "MTU for ${PPP_INTERFACE} is $INTERFACE_MTU, changing to $MTU"
-  sed -i "s/ ${INTERFACE_MTU}/ ${MTU}/g" "/etc/ppp/peers/${PPP_INTERFACE}"
-  ip link set dev ${WAN_INTERFACE} mtu $(( MTU + 8 ))
-  if [ -n "$VLAN_ID" ]; then
-    ip link set dev ${WAN_INTERFACE}.${VLAN_ID} mtu $(( MTU + 8 ))
-  fi
-  # This might not even be needed?
-  # ifconfig ${WAN_INTERFACE} down
-  # ifconfig ${WAN_INTERFACE} up
-  killall pppd
-  sleep 1
-  killall -q -HUP dnsmasq dnscrypt-proxy || :
-else
+if [ "$INTERFACE_MTU" -eq $MTU ]; then
   echo "MTU is OK"
+  exit 0
 fi
+
+model=$(ubnt-device-info model 2>/dev/null || :)
+
+case "$model" in
+  "UniFi Gateway Fiber" | "UniFi Cloud Gateway Fiber" )
+    case "${WAN_INTERFACE,,}" in
+      "eth0" | "eth1" | "eth2" | "eth3")
+        echo "ERROR: Your $model only supports changing the MTU for ports 5, 6, and 7."
+        exit 1 ;;
+    esac
+esac
+
+echo "MTU for ${PPP_INTERFACE} is $INTERFACE_MTU, changing to $MTU"
+
+sed -i "s/ ${INTERFACE_MTU}/ ${MTU}/g" "/etc/ppp/peers/${PPP_INTERFACE}"
+ip link set dev ${WAN_INTERFACE} mtu $(( MTU + 8 ))
+if [ -n "$VLAN_ID" ]; then
+  ip link set dev ${WAN_INTERFACE}.${VLAN_ID} mtu $(( MTU + 8 ))
+fi
+
+killall pppd
+sleep 1
+killall -q -HUP dnsmasq dnscrypt-proxy || :
+
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -103,6 +103,15 @@ chmod +x "$INSTALL_DIR/"*.sh
 log_info "Installing service..."
 cp "$INSTALL_DIR/fix-mtu.service" "$SERVICE_DEST"
 systemctl daemon-reload
+
 echo "Start with systemctl start fix-mtu.service"
 echo "Enable on boot with systemctl enable fix-mtu.service"
+
+model=$(ubnt-device-info model 2>/dev/null || :)
+
+case "$model" in
+  "UniFi Gateway Fiber" | "UniFi Cloud Gateway Fiber" )
+    echo && log_warn "Your $model only supports changing the MTU for ports 5, 6, and 7." && echo ;;
+esac
+
 log_info "Installation complete!"


### PR DESCRIPTION
Prints a warning when a Cloud Gateway Fiber is detected, about not setting WAN_INTERFACE lower than eth4.

Also surpresses the error when dnscrypt-proxy is not installed.

Fixes #8 